### PR TITLE
Add support on iOS for snapshot.key, update and once.

### DIFF
--- a/database.js
+++ b/database.js
@@ -303,9 +303,7 @@ export class DatabaseReference extends Query {
             ({ locationUrl }) => NativeFirebaseBridgeDatabase.setValue(locationUrl, [value]));
     }
 
-    update(value:any) : Promise {
-        // We wrap value in array for easier handling on Android.
-        // See FirebridgeDatabase.java setValue()
+    update(value:{ [key:string]: any }) : Promise {
         return this.parentPromise.then(
             ({ locationUrl }) => NativeFirebaseBridgeDatabase.update(locationUrl, value));
     }

--- a/ios/FirebaseBridge.m
+++ b/ios/FirebaseBridge.m
@@ -3,6 +3,12 @@
 
 @interface RCT_EXTERN_MODULE(FirebaseBridgeDatabase, NSObject)
 
+RCT_EXTERN_METHOD(once:(NSString)databaseUrl
+                  eventTypeString:(NSString)eventTypeString
+                  query:NSObject
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(on:(NSString)databaseUrl
                   eventTypeString:(NSString)eventTypeString
                   query:NSObject
@@ -31,7 +37,16 @@ RCT_EXTERN_METHOD(snapshotValue:(NSString)snapshotUUID
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(snapshotKey:(NSString)snapshotUUID
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(snapshotChildren:(NSString)snapshotUUID
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(update:(NSString)databaseUrl
+                  value:NSObject
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 


### PR DESCRIPTION
The Android support is still WIP.

database.js:
```
  DataSnapshot.key()
  Query.once(eventType:EventType, cb:((snapshot:DataSnapshot) => Promise)) : () => void
  DatabaseReference.update(value:any) : Promise

```
iOS implementation in FirebaseBridgeDatabase.swift
```
  @objc func snapshotKey(snapshotUUID: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock)
  @objc func onRef(databaseUrl: String?, eventTypeString:String, query: [[AnyObject]]) throws -> FIRDatabaseQuery
  @objc func update(databaseUrl:String, value:Dictionary<String, AnyObject>, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock)

```
and the needed updates in FirebaseBridge.m

As simple test context an example of the code i used to get things going is included below:

```
import Database from 'rn-firebase-bridge/database';
import { signInWithEmail } from 'rn-firebase-bridge/auth';

export default class FirebaseNativeService {

  constructor(layerContext) {
    this.layerContext = layerContext;

    if (FirebaseNativeService.databasePersistenceEnabled === undefined) {
      FirebaseNativeService.databasePersistenceEnabled = true;

      Database.setPersistenceEnabled(true);

      this.signIn('xxx@yyy.nl', 'ppp')
        .then(() => {
          this.test();
        });
    }
  }

  async test() {
    console.log('========== test called');
    return this.testSetUpdateRemove()
      .then(() => console.log('========== testSetUpdateRemove ok'))
      .catch(err => console.log('!!!!!!!!!! testSetUpdateRemove error:', err));
  }

  async testSetUpdateRemove() {
    console.log('====----------====== testSetUpdateRemove started');

    const testListenDisposers = await this.testListen();

    await this.testSetValues();
    const testSetValuesOkDisposers = await this.testSetValuesOk();

    await this.testUpdateValues();
    const testUpdateValuesOkDisposers = await this.testUpdatedValuesOk();

    await this.testRemoveValues();
    await this.testRemovedValuesOk();

    this.stopListeningOn(testListenDisposers);
    this.stopListeningOn(testSetValuesOkDisposers);
    this.stopListeningOn(testUpdateValuesOkDisposers);

    this.newId('testFirebaseNativeService/newId');

    console.log('====----------====== testSetUpdateRemove finished');
  }

  testRefAaa() {
    const ref = this.dbRef();
    return ref
      .child('testFirebaseNativeService/Aaa');
  }

  async testListen() {
    console.log('========== testListen started');
    const ref = this.testRefAaa();
    ref.toString().then(result => console.log('testListen on:', result), err => console.log('testListen error:', err));

    const disposers = {};
    disposers.testListen = ref.on('value', async (snapshot) => {
      await snapshot.forEach(async (child) => {
        const val = await child.val();
        const key = await child.key();
        console.log('testListen Child key:', key, 'val:', val);
      });
      console.log('testListen Snapshot val:', await snapshot.val(), ', key:', await snapshot.key());
    });
    return disposers;
  }

  async testSetValues() {
    console.log('========== testSetValues started');
    const ref = this.testRefAaa();
    return ref
      .setValue({ val1: 'val1', val2: { val2a: 'val2a', val2b: 'val2b' } })
      .then(
        () => {
          console.log('testSetValues ok');
        },
        err => console.log('testSetValues err:', err));
  }

  async testSetValuesOk() {
    console.log('========== testSetValuesOk started');
    const ref = this.testRefAaa();
    ref.toString().then(result => console.log('testSetValuesOk testRefAaa toString:', result), err => console.log('testSetValuesOk toString error:', err));

    const disposers = {};
    disposers.testSetValuesOkOne = ref.once('value', async (snapshot) => {
      await snapshot.forEach(async (child) => {
        const val = await child.val();
        const key = await child.key();
        console.log('testSetValuesOk Child key:', key, 'val:', val);
      });
      console.log('testSetValuesOk Snapshot val:', await snapshot.val(), ', key:', await snapshot.key());
    });
    return disposers;
  }

  async testUpdateValues() {
    console.log('========== testUpdateValues started');
    const ref = this.testRefAaa();
    return ref
      .update({ val3: 'val3', val2: { val2a: 'val2aUpdated', val2b: 'val2bUpdated' } })
      .then(
        () => {
          console.log('testUpdateValues ok');
        },
        err => console.log('testUpdateValues err:', err));
  }

  async testUpdatedValuesOk() {
    console.log('========== testUpdateValuesOk started');
    const ref = this.testRefAaa();

    const disposers = {};
    disposers.testSetValuesOkOne = ref.once('value', async (snapshot) => {
      await snapshot.forEach(async (child) => {
        const val = await child.val();
        const key = await child.key();
        console.log('testUpdatedValuesOk Child key:', key, 'val:', val);
      });
      console.log('testUpdatedValuesOk Snapshot val:', await snapshot.val(), ', key:', await snapshot.key());
    });
    return disposers;
  }

  async testRemoveValues() {
    console.log('========== testRemoveValues started');
    const ref = this.testRefAaa();
    return ref.remove()
      .then(
        () => {
          console.log('testRemoveValues ok');
        },
        err => console.log('testRemoveValues err:', err));
  }

  async testRemovedValuesOk() {
    console.log('========== testRemovedValues started');
    const ref = this.testRefAaa();
    return ref.once('value', async (snapshot) => {
      console.log('testRemovedValuesOk Snapshot exists:', await snapshot.exists());
    });
  }

  signIn(email, password) {
    return signInWithEmail(email, password).then(
        user => {
          console.log(user);
        },
        error => console.log(error)
    );
  }

  async newId(modelPath) {
    const idRef = this.dbRef().child(modelPath);
    const entityIdRef = idRef.push();
    const key = await entityIdRef.key();
    console.log('newId:', key);
    return key;
  }

  dbRef() {
    if (this.rootRef === undefined) {
      this.rootRef = Database
        .ref()
        .child(this.layerContext.databaseRoot || 'qqqq');
    }
    return this.rootRef;
  }
}
```