### PR TITLE
added a few functions for user manipulations

### DIFF
--- a/ios/FirebaseBridge.m
+++ b/ios/FirebaseBridge.m
@@ -105,7 +105,30 @@ RCT_EXTERN_METHOD(signInWithCredential:(NSString)credentialId
 
 RCT_EXTERN_METHOD(signOut:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
+
 @end
+
+@interface RCT_EXTERN_MODULE(FirebaseBridgeUser, NSObject)
+
+RCT_EXTERN_METHOD(updateEmail:(NSString)email
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(updatePassword:(NSString)email
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+
+RCT_EXTERN_METHOD(sendEmailVerification:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(reauthenticateWithCredential:(NSString)credentialId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+
+@end
+
 
 @interface RCT_EXTERN_MODULE(FirebaseBridgeFacebookAuthProvider, NSObject)
 

--- a/ios/FirebaseBridgeUser.swift
+++ b/ios/FirebaseBridgeUser.swift
@@ -1,0 +1,110 @@
+//
+//  FirebaseBridgeUser.swift
+//
+//  Created by Batuhan Icoz on 24/08/2016.
+//
+
+import Firebase
+
+@objc(FirebaseBridgeUser)
+class FirebaseBridgeUser : NSObject {
+  
+  var bridge: RCTBridge!
+  
+  override init() {
+    super.init()
+  }
+  
+  
+  @objc func updateEmail(email: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    
+    let user = FIRAuth.auth()?.currentUser
+    
+    user?.updateEmail(email) { error in
+      if let error = error {
+        var code = ""
+        if let errorCode = FIRAuthErrorCode(rawValue: error.code) {
+          code = authErrorCodeToString(errorCode)
+        } else if let userInfo = error.userInfo as? Dictionary<String, AnyObject> {
+          code = userInfo["error_name"] as! String
+        }
+        reject(code, error.localizedDescription, error);
+        return;
+      }
+
+      resolve(nil);
+    }
+  }
+  
+  
+  @objc func updatePassword(password: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    
+    let user = FIRAuth.auth()?.currentUser
+    
+    user?.updatePassword(password) { error in
+      if let error = error {
+        var code = ""
+        if let errorCode = FIRAuthErrorCode(rawValue: error.code) {
+          code = authErrorCodeToString(errorCode)
+        } else if let userInfo = error.userInfo as? Dictionary<String, AnyObject> {
+          code = userInfo["error_name"] as! String
+        }
+        reject(code, error.localizedDescription, error);
+        return;
+      }
+      resolve(nil);
+    }
+  }
+  
+  @objc func sendEmailVerification(resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    
+    let user = FIRAuth.auth()?.currentUser
+
+    user?.sendEmailVerificationWithCompletion() { error in
+      if let error = error {
+        var code = ""
+        if let errorCode = FIRAuthErrorCode(rawValue: error.code) {
+          code = authErrorCodeToString(errorCode)
+        } else if let userInfo = error.userInfo as? Dictionary<String, AnyObject> {
+          code = userInfo["error_name"] as! String
+        }
+        reject(code, error.localizedDescription, error);
+        return;
+      }
+      
+      resolve(nil);
+    }
+  }
+  
+  
+  @objc func reauthenticateWithCredential(credentialId: String, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+
+    if let credential = FirebaseBridgeCredentialCache.getCredential(credentialId) {
+
+      let user = FIRAuth.auth()?.currentUser
+
+      user?.reauthenticateWithCredential(credential, completion: { (error) in
+        if let error = error {
+
+          var code = ""
+          if let errorCode = FIRAuthErrorCode(rawValue: error.code) {
+            code = authErrorCodeToString(errorCode)
+          } else if let userInfo = error.userInfo as? Dictionary<String, AnyObject> {
+            code = userInfo["error_name"] as! String
+          }
+          
+          reject(code, error.localizedDescription, error);
+          return;
+        }
+
+        resolve(nil);
+        }
+      )
+    } else {
+      reject("auth/credential-not-found", "Credential not found", NSError(domain: "FirebaseBridgeAuth", code: 0, userInfo: nil));
+    }
+  }
+
+
+}
+

--- a/user.js
+++ b/user.js
@@ -1,0 +1,33 @@
+// @flow
+import { NativeModules, NativeEventEmitter } from 'react-native';
+import type { User } from './types';
+const NativeFirebaseBridgeUser = NativeModules.FirebaseBridgeUser;
+
+
+const updateEmail:(email:string) => Promise<null> =
+    NativeFirebaseBridgeUser.updateEmail;
+
+const updatePassword:(email:string) => Promise<null> =
+    NativeFirebaseBridgeUser.updatePassword;
+
+const sendEmailVerification:() => Promise<null> =
+    NativeFirebaseBridgeUser.sendEmailVerification;
+
+
+async function reauthenticateWithCredential(credential:AuthCredential|Promise<AuthCredential>) : Promise<null> {
+    return NativeFirebaseBridgeUser.reauthenticateWithCredential((await credential).id);
+}
+
+export default {
+    updateEmail,
+    updatePassword,
+    sendEmailVerification,
+    reauthenticateWithCredential,
+};
+
+export {
+    updateEmail,
+    updatePassword,
+    sendEmailVerification,
+    reauthenticateWithCredential,
+};


### PR DESCRIPTION
I've added bridges for 4 functions in the FIRUser class. Sadly, they are iOS only.

These are:

- updateEmail
- updatePassword
- sendEmailVerification
- reauthenticateWithCredential 

I'm new to iOS development (and Swift) so I'm not sure this is the correct way to implement these. I've tested them with our application and they work.
 
If this is OK, I'll all the other functions from this class (with documentation) and also some Analytics functions since we need them at our company.