### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.+'
-    compile 'com.google.firebase:firebase-core:9.6.1'
-    compile 'com.google.firebase:firebase-database:9.6.1'
-    compile 'com.google.firebase:firebase-auth:9.6.1'
+    compile 'com.google.firebase:firebase-core:+'
+    compile 'com.google.firebase:firebase-database:+'
+    compile 'com.google.firebase:firebase-auth:+'
 }


### PR DESCRIPTION
'+' is needed for firebase dependencies to be compatible with other packages.